### PR TITLE
Fix SEO meta tags and sitemap

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/png" href="icons/icon48.png">
     <meta name="description" content="Privacy Policy for QuizGPT - Learn how we protect your data">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://quizgpt.site/privacy.html">
 </head>
 <body class="legal">
     <nav class="navbar" role="navigation" aria-label="Main navigation">

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -5,4 +5,4 @@ Allow: /
 Sitemap: https://quizgpt.site/sitemap.xml
 
 # Crawl delay (optional)
-Crawl-delay: 1 
+Crawl-delay: 1

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,43 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://quizgpt.site/</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://quizgpt.site/guide.html</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://quizgpt.site/pricing.html</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>
     <url>
         <loc>https://quizgpt.site/privacy.html</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.5</priority>
     </url>
     <url>
         <loc>https://quizgpt.site/terms.html</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.5</priority>
     </url>
     <url>
         <loc>https://quizgpt.site/upgrade.html</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.7</priority>
     </url>
     <url>
         <loc>https://quizgpt.site/success.html</loc>
-        <lastmod>2025-01-27</lastmod>
+        <lastmod>2025-07-05</lastmod>
         <changefreq>yearly</changefreq>
         <priority>0.3</priority>
     </url>

--- a/docs/success.html
+++ b/docs/success.html
@@ -6,6 +6,8 @@
     <title>Payment Successful | QuizGPT</title>
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" type="image/png" href="icons/icon48.png">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://quizgpt.site/success.html">
 </head>
 <body class="success-page">
     <nav class="navbar" role="navigation" aria-label="Main navigation">

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/png" href="icons/icon48.png">
     <meta name="description" content="Terms of Service for QuizGPT - Learn about the terms and conditions of using our extension">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://quizgpt.site/terms.html">
 </head>
 <body class="legal">
     <nav class="navbar" role="navigation" aria-label="Main navigation">

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -6,6 +6,8 @@
     <title>Upgrade to Premium | QuizGPT</title>
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" type="image/png" href="icons/icon48.png">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://quizgpt.site/upgrade.html">
     <style>
         body.upgrade-page {
             background: linear-gradient(135deg, #8A2BE2 0%, #DA70D6 100%);


### PR DESCRIPTION
## Summary
- ensure privacy, terms, upgrade and success pages declare canonical URLs
- add robots meta to the same pages
- update sitemap with current date
- clean up robots.txt formatting

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68691a04a3ac8325bd184b92434acb13