### PR TITLE
Fix canonical URL and update robots

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:title" content="QuizGPT – Best Kahoot Bot & Auto Answer Extension">
     <meta name="twitter:description" content="Get instant, accurate answers for Kahoot quizzes using AI. The most reliable Kahoot cheat that works in 2025.">
     <meta name="twitter:image" content="https://quizgpt.site/icons/icon512.png">
-    <link rel="canonical" href="https://quizgpt.site">
+    <link rel="canonical" href="https://quizgpt.site/">
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/png" href="icons/icon48.png">
     <script type="application/ld+json">

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /index.html
 
 # Sitemap location
 Sitemap: https://quizgpt.site/sitemap.xml


### PR DESCRIPTION
## Summary
- set canonical on index.html to `https://quizgpt.site/`
- disallow `index.html` in `robots.txt`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688a957cf04c8325b217de4008a41c8a